### PR TITLE
54 - validate state or wine region is set on appellation

### DIFF
--- a/app/models/appellation.rb
+++ b/app/models/appellation.rb
@@ -1,8 +1,15 @@
 class Appellation < ApplicationRecord
   validates_presence_of :name
+  validate :presence_of_state_or_wine_region
   belongs_to :wine_region, optional: true
   belongs_to :state, optional: true
   has_and_belongs_to_many :varietals
   has_many :wines
   has_and_belongs_to_many :blends
+
+  def presence_of_state_or_wine_region
+    unless wine_region.present? || state.present?
+      errors.add(:wine_region, "State, wine region, or both must be set")
+    end
+  end
 end


### PR DESCRIPTION
Appellations must have state, wine region, or both set on a record in order to be valid.

https://trello.com/c/aVWAi5nL/54-add-custom-model-validation-for-appellation
