### PR TITLE
59 - new rake task db:rebuild which replaces broken db:reset

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,10 @@
+namespace :db do
+  desc "db:reset is broken, this does what that tries to do. Drop, create, migrate and seed."
+  task rebuild: :environment do
+    Rake::Task["db:drop"].invoke
+    Rake::Task["db:create"].invoke
+    Rake::Task["db:migrate"].invoke
+    Rake::Task["db:seed"].invoke
+  end
+
+end


### PR DESCRIPTION
card: https://trello.com/c/Vll6aFPr

rake db:reset is broken. It does not honor validations or throwing exceptions within the seeds.rb file. 
https://github.com/rails/rails/issues/23854
It also allows migrations to run which should fail due to table creation being in the wrong order (didn't hunt down a rails issue for that one, just going to abandon db:reset)

Create a rake task rake db:rebuild

it will 
db:drop
db:create
db:migrate
db:seed
