### PR TITLE
 78 - removed embedding nested records in the primary data for JSON:API com…

### DIFF
--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -10,7 +10,7 @@ class CountriesController < ApplicationController
 
   # GET /countries/1
   def show
-    render json: @country
+    render json: @country, include: params[:include]
   end
 
   # POST /countries

--- a/app/models/appellation.rb
+++ b/app/models/appellation.rb
@@ -4,8 +4,8 @@ class Appellation < ApplicationRecord
   belongs_to :wine_region, optional: true
   belongs_to :state, optional: true
   has_and_belongs_to_many :varietals
-  has_many :wines
   has_and_belongs_to_many :blends
+  has_many :wines
 
   def presence_of_state_or_wine_region
     unless wine_region.present? || state.present?

--- a/app/models/blend.rb
+++ b/app/models/blend.rb
@@ -1,5 +1,6 @@
 class Blend < ApplicationRecord
   validates_presence_of :name
+
   has_and_belongs_to_many :varietals
   has_and_belongs_to_many :appellations
   has_and_belongs_to_many :wine_regions

--- a/app/models/varietal.rb
+++ b/app/models/varietal.rb
@@ -1,6 +1,7 @@
 class Varietal < ApplicationRecord
   validates_presence_of :name
   validates_inclusion_of :is_black, in: [true, false]
+
   has_and_belongs_to_many :blends
   has_and_belongs_to_many :countries
   has_and_belongs_to_many :wine_regions

--- a/app/models/wine.rb
+++ b/app/models/wine.rb
@@ -1,7 +1,6 @@
 class Wine < ApplicationRecord
   belongs_to :wine_type
   belongs_to :country
-
   belongs_to :wine_region, optional: true
   belongs_to :state, optional: true
   belongs_to :appellation, optional: true

--- a/app/models/wine_region.rb
+++ b/app/models/wine_region.rb
@@ -1,9 +1,10 @@
 class WineRegion < ApplicationRecord
   validates_presence_of :name
+
   belongs_to :country
-  has_many :appellations
   belongs_to :state, optional: true
   has_and_belongs_to_many :varietals
-  has_many :wines
   has_and_belongs_to_many :blends
+  has_many :wines
+  has_many :appellations
 end

--- a/app/serializers/appellation_serializer.rb
+++ b/app/serializers/appellation_serializer.rb
@@ -1,9 +1,9 @@
 class AppellationSerializer < ActiveModel::Serializer
-  attributes :id, :name, :wine_region, :state, :blends, :varietals
+  attributes :id, :name
 
   belongs_to :wine_region
   belongs_to :state
-  has_many :varietals, serializer: VarietalSerializer
+  has_many :varietals
+  has_many :blends
   has_many :wines
-  has_many :blends, serializer: BlendSerializer
 end

--- a/app/serializers/blend_serializer.rb
+++ b/app/serializers/blend_serializer.rb
@@ -1,5 +1,5 @@
 class BlendSerializer < ActiveModel::Serializer
-  attributes :id, :name, :varietals
+  attributes :id, :name
 
   has_many :varietals
   has_many :wines

--- a/app/serializers/country_serializer.rb
+++ b/app/serializers/country_serializer.rb
@@ -1,10 +1,10 @@
 class CountrySerializer < ActiveModel::Serializer
-  attributes :id, :name, :wine_regions, :states, :varietals, :blends
+  attributes :id, :name 
 
   has_many :wines
   has_many :wine_regions
   has_many :states
 
-  has_many :varietals, serializer: VarietalSerializer
+  has_many :varietals
   has_many :blends
 end

--- a/app/serializers/state_serializer.rb
+++ b/app/serializers/state_serializer.rb
@@ -1,5 +1,5 @@
 class StateSerializer < ActiveModel::Serializer
-  attributes :id, :name, :wine_regions, :country, :appellations
+  attributes :id, :name
 
   belongs_to :country
   has_many :wine_regions

--- a/app/serializers/varietal_serializer.rb
+++ b/app/serializers/varietal_serializer.rb
@@ -1,6 +1,7 @@
 class VarietalSerializer < ActiveModel::Serializer
-  attributes :id, :name, :is_black, :countries, :blends
-  has_many :countries, serializer: CountrySerializer
+  attributes :id, :name, :is_black
+
+  has_many :countries
   has_many :wines
   has_many :blends
 end

--- a/app/serializers/wine_region_serializer.rb
+++ b/app/serializers/wine_region_serializer.rb
@@ -1,5 +1,5 @@
 class WineRegionSerializer < ActiveModel::Serializer
-  attributes :id, :name, :country, :state, :appellations, :varietals, :blends
+  attributes :id, :name
 
   belongs_to :country
   belongs_to :state, optional: true

--- a/app/serializers/wine_serializer.rb
+++ b/app/serializers/wine_serializer.rb
@@ -1,5 +1,5 @@
 class WineSerializer < ActiveModel::Serializer
-  attributes :id, :name, :country, :wine_type, :varietal, :blend
+  attributes :id, :name
  
   belongs_to :wine_type
   belongs_to :country


### PR DESCRIPTION
…pliance

https://trello.com/c/Zsw5ncpp/78-edit-api-so-it-conforms-to-jsonapi-standards-and-sends-related-records-only-on-request

Previously the api was sending related records nested within the parent object, which is not JSON:API compliant.

To obtain related/nested records, the request must be passed the ?includes=relatedRecordName param and it will return those records in an array named "included"
